### PR TITLE
Make ansible_config_get raise an error when configuration item is missing

### DIFF
--- a/test/test_prerun.py
+++ b/test/test_prerun.py
@@ -213,6 +213,27 @@ def test_ansible_config_get() -> None:
     assert len(paths) > 0
 
 
+@pytest.mark.parametrize(
+    "default",
+    (
+        (None,),
+        (123,),
+    ),
+)
+def test_ansible_config_get_default(default: object) -> None:
+    """Check that config get returns default when appropriate."""
+    result = prerun.ansible_config_get("NON_EXISTING_OPTION", default=default)
+    assert result is default
+
+
+def test_ansible_config_get_raise() -> None:
+    """Check that config get raise if key is not found."""
+    key = "NON_EXISTING_OPTION"
+    with pytest.raises(KeyError) as exc:
+        prerun.ansible_config_get(key)
+    assert exc.value.args[0] == key
+
+
 def test_install_collection() -> None:
     """Check that valid collection installs do not fail."""
     prerun.install_collection("containers.podman:>=1.0")


### PR DESCRIPTION
- change implementation to raise KeyError by default for missing keys
- allow setting a default value, including None
- this would count as major change but because we do not have any release, it should only worth mentioning that in order to keep old behavior user would have to call it with `default=None`.

Follow-Up: https://github.com/ansible-community/ansible-compat/pull/5#discussion_r659281990