### PR TITLE
Replace sys.exit with exceptions

### DIFF
--- a/src/ansible_compat/config.py
+++ b/src/ansible_compat/config.py
@@ -3,14 +3,13 @@ import ast
 import os
 import re
 import subprocess
-import sys
 from collections import UserDict
 from functools import lru_cache
 from typing import TYPE_CHECKING, List, Optional, Tuple
 
 from packaging.version import Version
 
-from ansible_compat.constants import ANSIBLE_MISSING_RC
+from ansible_compat.errors import MissingAnsibleError
 
 if TYPE_CHECKING:
     # https://github.com/PyCQA/pylint/issues/3285
@@ -75,13 +74,13 @@ def ansible_version(version: str = "") -> Version:
         version, error = parse_ansible_version(proc.stdout)
         if error is not None:
             print(error)
-            sys.exit(ANSIBLE_MISSING_RC)
+            raise MissingAnsibleError()
     else:
         print(
             "Unable to find a working copy of ansible executable.",
             proc,
         )
-        sys.exit(ANSIBLE_MISSING_RC)
+        raise MissingAnsibleError()
     return Version(version)
 
 

--- a/src/ansible_compat/errors.py
+++ b/src/ansible_compat/errors.py
@@ -1,0 +1,20 @@
+"""Module to deal with errors."""
+from ansible_compat.constants import ANSIBLE_MISSING_RC, INVALID_PREREQUISITES_RC
+
+
+class AnsibleCompatError(RuntimeError):
+    """Generic error originating from ansible_compat library."""
+
+    code = 1  # generic error
+
+
+class MissingAnsibleError(AnsibleCompatError):
+    """Reports a missing or broken Ansible installation."""
+
+    code = ANSIBLE_MISSING_RC
+
+
+class InvalidPrerequisiteError(AnsibleCompatError):
+    """Reports a missing requirement."""
+
+    code = INVALID_PREREQUISITES_RC

--- a/test/test_prerun.py
+++ b/test/test_prerun.py
@@ -12,6 +12,7 @@ from flaky import flaky
 
 from ansible_compat import prerun
 from ansible_compat.constants import INVALID_PREREQUISITES_RC
+from ansible_compat.errors import AnsibleCompatError, InvalidPrerequisiteError
 
 
 @contextmanager
@@ -185,9 +186,9 @@ def test_require_collection_wrong_version() -> None:
             "~/.ansible/collections",
         ]
     )
-    with pytest.raises(SystemExit) as pytest_wrapped_e:
+    with pytest.raises(InvalidPrerequisiteError) as pytest_wrapped_e:
         prerun.require_collection("containers.podman", '9999.9.9')
-    assert pytest_wrapped_e.type == SystemExit
+    assert pytest_wrapped_e.type == InvalidPrerequisiteError
     assert pytest_wrapped_e.value.code == INVALID_PREREQUISITES_RC
 
 
@@ -200,9 +201,9 @@ def test_require_collection_wrong_version() -> None:
 )
 def test_require_collection_missing(name: str, version: str) -> None:
     """Tests behaviour of require_collection, missing case."""
-    with pytest.raises(SystemExit) as pytest_wrapped_e:
+    with pytest.raises(AnsibleCompatError) as pytest_wrapped_e:
         prerun.require_collection(name, version)
-    assert pytest_wrapped_e.type == SystemExit
+    assert pytest_wrapped_e.type == InvalidPrerequisiteError
     assert pytest_wrapped_e.value.code == INVALID_PREREQUISITES_RC
 
 
@@ -241,7 +242,7 @@ def test_install_collection() -> None:
 
 def test_install_collection_fail() -> None:
     """Check that invalid collection install fails."""
-    with pytest.raises(SystemExit) as pytest_wrapped_e:
+    with pytest.raises(AnsibleCompatError) as pytest_wrapped_e:
         prerun.install_collection("containers.podman:>=9999.0")
-    assert pytest_wrapped_e.type == SystemExit
+    assert pytest_wrapped_e.type == InvalidPrerequisiteError
     assert pytest_wrapped_e.value.code == INVALID_PREREQUISITES_RC


### PR DESCRIPTION
Fatal errors now raise as exceptions instead of using sys.exit(). This should make it much easier to reuse code.