### PR TITLE
Add ability to check minimal ansible version

### DIFF
--- a/src/ansible_compat/runtime.py
+++ b/src/ansible_compat/runtime.py
@@ -50,6 +50,7 @@ class Runtime:
         self,
         project_dir: Optional[str] = None,
         isolated: bool = False,
+        min_required_version: Optional[str] = None,
     ) -> None:
         """Initialize Ansible runtime environment.
 
@@ -59,12 +60,23 @@ class Runtime:
         :param isolated: Assure that installation of collections or roles
                          does not affect Ansible installation, an unique cache
                          directory being used instead.
+        :param min_required_version: Minimal version of Ansible required. If
+                                     not found, a :class:`RuntimeError`
+                                     exception is raised.
         """
         self.project_dir = project_dir or os.getcwd()
         self.isolated = isolated
         if isolated:
             self.cache_dir = get_cache_dir(self.project_dir)
         self.config = AnsibleConfig()
+
+        if (
+            min_required_version is not None
+            and packaging.version.Version(min_required_version) > self.version
+        ):
+            raise RuntimeError(
+                f"Found incompatible version of ansible runtime {self.version}, instead of {min_required_version} or newer."
+            )
 
     def clean(self) -> None:
         """Remove content of cache_dir."""

--- a/test/test_runtime.py
+++ b/test/test_runtime.py
@@ -26,6 +26,12 @@ def test_runtime_version(runtime: Runtime) -> None:
     assert version == runtime.version
 
 
+def test_runtime_version_outdated() -> None:
+    """Checks that instantiation raises if version is outdated."""
+    with pytest.raises(RuntimeError, match="Found incompatible version of ansible"):
+        Runtime(min_required_version="9999.9.9")
+
+
 def test_runtime_version_fail(mocker: MockerFixture) -> None:
     """Tests for failure to detect Ansible version."""
     mocker.patch(

--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,7 @@ setenv =
   PIP_DISABLE_PIP_VERSION_CHECK = 1
   PIP_CONSTRAINT = {toxinidir}/constraints.txt
   PRE_COMMIT_COLOR = always
-  PYTEST_REQPASS = 29
+  PYTEST_REQPASS = 30
   FORCE_COLOR = 1
 allowlist_externals =
   sh


### PR DESCRIPTION
This will allow us to remove the old `prerun.check_ansible_presence` implementation and make instantiation quite nice an easy.

Also this approach is compatible with a possible future use of ansible-runner.

Partial-Fix: #6