### PR TITLE
Reorganize documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,11 @@
 # ansible-compat
 
+[![pypi](https://img.shields.io/pypi/v/ansible-compat.svg)](https://pypi.org/project/ansible-compat/)
+[![docs](https://readthedocs.org/projects/ansible-compat/badge/?version=latest)](https://ansible-compat.readthedocs.io/en/latest/)
+[![gh](https://github.com/ansible-community/ansible-compat/actions/workflows/tox.yml/badge.svg)](https://github.com/ansible-community/ansible-compat/actions/workflows/tox.yml)
+[![codecov.io](https://codecov.io/github/ansible-community/ansible-compat/coverage.svg?branch=main)](https://codecov.io/github/ansible-community/ansible-compat?branch=main)
+
 A python package contains functions that facilitate working with various
 versions of Ansible 2.9 and newer.
 
-## Using Ansible runtime
-
-```python
-from ansible_compat.runtime import Runtime
-
-def test_runtime():
-
-    # instantiate the runtime using isolated mode, so installing new
-    # roles/collections do not pollute the default setup.
-    runtime = Runtime(isolated=True)
-
-    # Print Ansible core version
-    print(runtime.version)  # 2.9.10 (Version object)
-    # Get configuration info from runtime
-    print(runtime.config.collections_path)
-
-    # Install a new collection
-    runtime.install_collection("containers.podman")
-
-    # Execute a command
-    result = runtime.exec(["ansible-doc", "--list"])
-```
-
-## Access to Ansible configuration
-
-As you may not want to parse `ansible-config dump` yourself, you
-can make use of a simple python class that facilitates access to
-it, using python data types.
-
-```python
-from ansible_compat.config import AnsibleConfig
-
-
-def test_example_config():
-    cfg = AnsibleConfig()
-    assert isinstance(cfg.ACTION_WARNINGS, bool)
-    # you can also use lowercase:
-    assert isinstance(cfg.action_warnings, bool)
-    # you can also use it as dictionary
-    assert cfg['action_warnings'] == cfg.action_warnings
-```
+Documentation is available at [ansible-compat.readthedocs.io](https://ansible-compat.readthedocs.io/en/latest/).

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,4 +1,6 @@
-### Using Ansible runtime
+# Examples
+
+## Using Ansible runtime
 
 ```python
 from ansible_compat.runtime import Runtime
@@ -21,7 +23,7 @@ def test_runtime():
     result = runtime.exec(["ansible-doc", "--list"])
 ```
 
-### Access to Ansible configuration
+## Access to Ansible configuration
 
 As you may not want to parse `ansible-config dump` yourself, you
 can make use of a simple python class that facilitates access to

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -2,25 +2,8 @@
 
 ## Using Ansible runtime
 
-```python
-from ansible_compat.runtime import Runtime
-
-def test_runtime():
-
-    # instantiate the runtime using isolated mode, so installing new
-    # roles/collections do not pollute the default setup.
-    runtime = Runtime(isolated=True)
-
-    # Print Ansible core version
-    print(runtime.version)  # 2.9.10 (Version object)
-    # Get configuration info from runtime
-    print(runtime.config.collections_path)
-
-    # Install a new collection
-    runtime.install_collection("containers.podman")
-
-    # Execute a command
-    result = runtime.exec(["ansible-doc", "--list"])
+```{literalinclude} ../test/test_runtime_example.py
+:language: python
 ```
 
 ## Access to Ansible configuration
@@ -29,15 +12,6 @@ As you may not want to parse `ansible-config dump` yourself, you
 can make use of a simple python class that facilitates access to
 it, using python data types.
 
-```python
-from ansible_compat.config import AnsibleConfig
-
-
-def test_example_config():
-    cfg = AnsibleConfig()
-    assert isinstance(cfg.ACTION_WARNINGS, bool)
-    # you can also use lowercase:
-    assert isinstance(cfg.action_warnings, bool)
-    # you can also use it as dictionary
-    assert cfg['action_warnings'] == cfg.action_warnings
+```{literalinclude} ../test/test_configuration_example.py
+:language: python
 ```

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,41 @@
+### Using Ansible runtime
+
+```python
+from ansible_compat.runtime import Runtime
+
+def test_runtime():
+
+    # instantiate the runtime using isolated mode, so installing new
+    # roles/collections do not pollute the default setup.
+    runtime = Runtime(isolated=True)
+
+    # Print Ansible core version
+    print(runtime.version)  # 2.9.10 (Version object)
+    # Get configuration info from runtime
+    print(runtime.config.collections_path)
+
+    # Install a new collection
+    runtime.install_collection("containers.podman")
+
+    # Execute a command
+    result = runtime.exec(["ansible-doc", "--list"])
+```
+
+### Access to Ansible configuration
+
+As you may not want to parse `ansible-config dump` yourself, you
+can make use of a simple python class that facilitates access to
+it, using python data types.
+
+```python
+from ansible_compat.config import AnsibleConfig
+
+
+def test_example_config():
+    cfg = AnsibleConfig()
+    assert isinstance(cfg.ACTION_WARNINGS, bool)
+    # you can also use lowercase:
+    assert isinstance(cfg.action_warnings, bool)
+    # you can also use it as dictionary
+    assert cfg['action_warnings'] == cfg.action_warnings
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,12 +15,3 @@
    :members:
    :special-members: __init__
 ```
-
-## Indices and tables
-
-```{eval-rst}
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
-
-```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,10 @@
 # ansible-compat
 
+```{include} examples.md
+```
+
+## API
+
 ```{eval-rst}
 .. toctree::
    :maxdepth: 2
@@ -17,4 +22,5 @@
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
+
 ```

--- a/test/test_configuration_example.py
+++ b/test/test_configuration_example.py
@@ -1,0 +1,12 @@
+"""Sample usage of AnsibleConfig."""
+from ansible_compat.config import AnsibleConfig
+
+
+def test_example_config() -> None:
+    """Test basic functionality of AnsibleConfig."""
+    cfg = AnsibleConfig()
+    assert isinstance(cfg.ACTION_WARNINGS, bool)
+    # you can also use lowercase:
+    assert isinstance(cfg.action_warnings, bool)
+    # you can also use it as dictionary
+    assert cfg['action_warnings'] == cfg.action_warnings

--- a/test/test_runtime_example.py
+++ b/test/test_runtime_example.py
@@ -1,0 +1,21 @@
+"""Sample use of Runtime class."""
+from ansible_compat.runtime import Runtime
+
+
+def test_runtime() -> None:
+    """Test basic functionality of Runtime class."""
+    # instantiate the runtime using isolated mode, so installing new
+    # roles/collections do not pollute the default setup.
+    runtime = Runtime(isolated=True)
+
+    # Print Ansible core version
+    print(runtime.version)  # 2.9.10 (Version object)
+    # Get configuration info from runtime
+    print(runtime.config.collections_path)
+
+    # Install a new collection
+    runtime.install_collection("containers.podman")
+
+    # Execute a command
+    result = runtime.exec(["ansible-doc", "--list"])
+    assert result.returncode == 0


### PR DESCRIPTION
- move examples into standalone file which is included in builded doc
- put link from project readme to documentation site
- include few basic badges in project readme