### PR TITLE
Drop use of pylint-pytest

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -120,10 +120,8 @@ repos:
   hooks:
   - id: pylint
     additional_dependencies:
-    - .
     - PyYAML
     - flaky
-    - pylint-pytest
     - pytest
     - tenacity
     - typing_extensions

--- a/.pylintrc
+++ b/.pylintrc
@@ -12,9 +12,6 @@ good-names=f,  # filename
 preferred-modules =
     unittest:pytest,
 
-[MASTER]
-load-plugins=pylint_pytest
-
 [MESSAGES CONTROL]
 
 disable =


### PR DESCRIPTION
Remove integration of pylint-pytest as it seems to not produce very reliable results both locally on on CI. Even worse the way F6401 because it only confuses the user, making much harder to identify what was the root cause.

One practical example is the output seen on https://github.com/ansible-community/ansible-compat/pull/32/checks?check_run_id=3161131064

Related: https://github.com/reverbc/pylint-pytest/issues/21