### PR TITLE
Ensure we encourage consistent use of config values

### DIFF
--- a/src/ansible_compat/config.py
+++ b/src/ansible_compat/config.py
@@ -5,6 +5,7 @@ import os
 import re
 import subprocess
 import sys
+import warnings
 from collections import UserDict
 from functools import lru_cache
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
@@ -98,8 +99,7 @@ class AnsibleConfig(_UserDict):  # pylint: disable=too-many-ancestors
     """
 
     _aliases = {
-        'COLLECTIONS_PATHS': 'COLLECTIONS_PATH',  # 2.9 -> 2.10+
-        'COLLECTIONS_PATH': 'COLLECTIONS_PATHS',  # 2.10+ -> 2.9
+        'COLLECTIONS_PATH': 'COLLECTIONS_PATHS',  # 2.9 -> 2.10
     }
     # Expose some attributes to enable auto-complete in editors, based on
     # https://docs.ansible.com/ansible/latest/reference_appendices/config.html
@@ -454,6 +454,10 @@ class AnsibleConfig(_UserDict):  # pylint: disable=too-many-ancestors
         if name in self.data:
             return self.data[name]
         if name in self._aliases:
+            warnings.warn(
+                f'Detected deprecated use of {name}, replace it with {self._aliases[name]}',
+                category=DeprecationWarning,
+            )
             return self.data[self._aliases[name]]
         raise AttributeError(attr_name)
 

--- a/src/ansible_compat/runtime.py
+++ b/src/ansible_compat/runtime.py
@@ -45,7 +45,6 @@ class Runtime:
 
     _version: Optional[packaging.version.Version] = None
     cache_dir: Optional[str] = None
-    collections_path: List[str]
 
     def __init__(
         self,
@@ -255,7 +254,7 @@ class Runtime:
                 "Invalid collection name supplied: %s" % name
             ) from exc
 
-        paths = self.config.collections_path
+        paths = self.config.collections_paths
         if not paths or not isinstance(paths, list):
             raise InvalidPrerequisiteError(
                 f"Unable to determine ansible collection paths. ({paths})"

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -18,7 +18,9 @@ def test_config() -> None:
 
     # check lowercase and older name aliasing
     assert isinstance(config.collections_paths, list)
-    assert isinstance(config.collections_path, list)
+
+    with pytest.warns(DeprecationWarning, match='Detected deprecated use of'):
+        assert isinstance(config.collections_path, list)
 
     with pytest.raises(AttributeError):
         print(config.THIS_DOES_NOT_EXIST)

--- a/test/test_runtime.py
+++ b/test/test_runtime.py
@@ -373,7 +373,7 @@ def test_require_collection_invalid_name(runtime: Runtime) -> None:
 
 def test_require_collection_invalid_collections_path(runtime: Runtime) -> None:
     """Check that require_collection raise with invalid collections path."""
-    runtime.config.collections_path = '/that/is/invalid'  # type: ignore
+    runtime.config.collections_paths = '/that/is/invalid'  # type: ignore
     with pytest.raises(
         InvalidPrerequisiteError, match="Unable to determine ansible collection paths"
     ):
@@ -383,7 +383,7 @@ def test_require_collection_invalid_collections_path(runtime: Runtime) -> None:
 def test_require_collection_preexisting_broken(tmp_path: pathlib.Path) -> None:
     """Check that require_collection raise with broken pre-existing collection."""
     runtime = Runtime(isolated=True, project_dir=str(tmp_path))
-    dest_path: str = runtime.config.collections_path[0]  # type: ignore
+    dest_path: str = runtime.config.collections_paths[0]
     dest = os.path.join(dest_path, "ansible_collections", "foo", "bar")
     os.makedirs(dest, exist_ok=True)
     with pytest.raises(InvalidPrerequisiteError, match="missing MANIFEST.json"):


### PR DESCRIPTION
Replace previous double directional use of aliases for renamed options, raise warnings when deprecated names are used.