### PR TITLE
Tune codecov reports

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,1 +1,6 @@
 comment: false
+coverage:
+  status:
+    default:
+      threshold: 0.5%
+    patch: off


### PR DESCRIPTION
- remove path report, we care only about whole project coverage
- configure threshold to 0.5% which should be small enough to hide
  rounding errors while not allowing regression in coverage.