### PR TITLE
Remove deprecation warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,10 @@ profile = "black"
 
 [tool.pytest.ini_options]
 addopts = "--no-success-flaky-report"
+# ensure we treat warnings as error
+filterwarnings = [
+  "error",
+]
 
 [tool.setuptools_scm]
 local_scheme = "no-local-version"

--- a/src/ansible_compat/config.py
+++ b/src/ansible_compat/config.py
@@ -5,7 +5,6 @@ import os
 import re
 import subprocess
 import sys
-import warnings
 from collections import UserDict
 from functools import lru_cache
 from typing import TYPE_CHECKING, Dict, List, Optional, Union
@@ -448,11 +447,6 @@ class AnsibleConfig(_UserDict):  # pylint: disable=too-many-ancestors
         if name in self.data:
             return self.data[name]
         if name in self._aliases:
-            warnings.warn(
-                f'Detected deprecated use of {name}, replace it with {self._aliases[name]}',
-                category=DeprecationWarning,
-                stacklevel=2,
-            )
             return self.data[self._aliases[name]]
         raise AttributeError(attr_name)
 

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -20,9 +20,7 @@ def test_config() -> None:
 
     # check lowercase and older name aliasing
     assert isinstance(config.collections_paths, list)
-
-    with pytest.warns(DeprecationWarning, match='Detected deprecated use of'):
-        assert isinstance(config.collections_path, list)
+    assert isinstance(config.collections_path, list)
 
     with pytest.raises(AttributeError):
         print(config.THIS_DOES_NOT_EXIST)


### PR DESCRIPTION
It seems that our attempt to recommend use of specific
names does trigger runtime warnings from within the library itself,
risking to confuse users.