### PR TITLE
chore: clarify versions of ansible used during testing

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -182,12 +182,8 @@ jobs:
         --skip-missing-interpreters false
         -vv
       env:
-        TOXENV: ${{ matrix.tox_env }},${{ matrix.tox_env }}-ansible29,${{ matrix.tox_env }}-ansible210,${{ matrix.tox_env }}-devel
+        TOXENV: ${{ matrix.tox_env }},${{ matrix.tox_env }}-ansible29,${{ matrix.tox_env }}-ansible210,${{ matrix.tox_env }}-ansible211,${{ matrix.tox_env }}-devel
     # sequential run improves browsing experience (almost no speed impact)
-    - name: "Test with tox: ${{ matrix.tox_env }}"
-      run: python3 -m tox
-      env:
-        TOXENV: ${{ matrix.tox_env }}
     - name: "Test with tox: ${{ matrix.tox_env }}-ansible29"
       run: python3 -m tox
       env:
@@ -196,6 +192,10 @@ jobs:
       run: python3 -m tox
       env:
         TOXENV: ${{ matrix.tox_env }}-ansible210
+    - name: "Test with tox: ${{ matrix.tox_env }}-ansible211"
+      run: python3 -m tox
+      env:
+        TOXENV: ${{ matrix.tox_env }}-ansible211
     - name: "Test with tox: ${{ matrix.tox_env }}-devel"
       run: python3 -m tox
       env:

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.16.1
-envlist = lint,packaging,docs,py{39,38,37,36},py{39,38,37,36}-{ansible29,ansible210,devel}
+envlist = lint,packaging,docs,py{39,38,37,36}-{ansible29,ansible210,ansible211,devel}
 isolated_build = true
 requires =
   setuptools >= 41.4.0
@@ -13,12 +13,14 @@ description =
   devel: ansible devel branch
   ansible29: ansible 2.9
   ansible210: ansible-base 2.10
+  ansible211: ansible-core 2.11
 extras =
   retry
   test
 deps =
   ansible29: ansible>=2.9,<2.10
   ansible210: ansible-base>=2.10,<2.11
+  ansible211: ansible-core>=2.11,<2.12
   devel: ansible-core @ git+https://github.com/ansible/ansible.git  # GPLv3+
 commands =
   ansible --version


### PR DESCRIPTION
Assures we list version of ansible used by each tox environment.
This makes it move explicit and easier to identify bugs.