### PR TITLE
Fix default value for roles path

### DIFF
--- a/src/ansible_compat/config.py
+++ b/src/ansible_compat/config.py
@@ -240,7 +240,8 @@ class AnsibleConfig(_UserDict):  # pylint: disable=too-many-ancestors
     default_remote_user: Optional[str] = None
     default_roles_path: List[str] = [
         "~/.ansible/roles",
-        "/usr/share/ansible/roles:/etc/ansible/roles",
+        "/usr/share/ansible/roles",
+        "/etc/ansible/roles",
     ]
     default_selinux_special_fs: List[str] = [
         "fuse",


### PR DESCRIPTION
While this was not directly used, it makes no sense to keep the wrong default value inside.