### PR TITLE
Fix config defaults

### DIFF
--- a/test/test_config.py
+++ b/test/test_config.py
@@ -28,6 +28,7 @@ def test_config() -> None:
     # check lowercase and older name aliasing
     assert isinstance(config.collections_paths, list)
     assert isinstance(config.collections_path, list)
+    assert config.collections_paths == config.collections_path
 
     with pytest.raises(AttributeError):
         print(config.THIS_DOES_NOT_EXIST)

--- a/test/test_runtime.py
+++ b/test/test_runtime.py
@@ -539,3 +539,14 @@ def test_require_collection_no_cache_dir() -> None:
     runtime = Runtime()
     assert not runtime.cache_dir
     runtime.require_collection("community.molecule", "0.1.0", install=True)
+
+
+def test_runtime_env_ansible_library(monkeypatch: MonkeyPatch) -> None:
+    """Verify that custom path specified using ANSIBLE_LIBRARY is not lost."""
+    path_name = "foo"
+    monkeypatch.setenv("ANSIBLE_LIBRARY", path_name)
+
+    path_name = os.path.realpath(path_name)
+    runtime = Runtime()
+    runtime.prepare_environment()
+    assert path_name in runtime.config.default_module_path

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ setenv =
   PIP_DISABLE_PIP_VERSION_CHECK = 1
   PIP_CONSTRAINT = {toxinidir}/constraints.txt
   PRE_COMMIT_COLOR = always
-  PYTEST_REQPASS = 61
+  PYTEST_REQPASS = 62
   FORCE_COLOR = 1
 allowlist_externals =
   sh


### PR DESCRIPTION
Fixes regression that happened with retrieval of configuration when we added default class attributes, so we would be able to benefit from editing hints.

We must use `__getattribute__` instead of `__getattr__` because the former one would just return our  class attributes instead of our real configuration from data dictionary.

Also adds one test that would have being failing before this bugfix.