### PR TITLE
Add portable cache implementation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -108,6 +108,7 @@ repos:
     # empty args needed in order to match mypy cli behavior
     args: ["--strict"]
     additional_dependencies:
+    - cached_property
     - flaky
     - packaging
     - pytest

--- a/mypy.ini
+++ b/mypy.ini
@@ -14,8 +14,12 @@ exclude = test/local-content
 [mypy-ansible.release]
 ignore_missing_imports = True
 
+[mypy-cached_property]
+# https://github.com/pydanny/cached-property/issues/172
+ignore_missing_imports = True
+
 [mypy-flaky]
-# # https://github.com/box/flaky/issues/170
+# https://github.com/box/flaky/issues/170
 ignore_missing_imports = True
 
 [mypy-pytest]

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,6 +62,7 @@ setup_requires =
 
 # These are required in actual runtime:
 install_requires =
+  cached_property ~= 1.5; python_version<="3.7"
   PyYAML
 
 [options.extras_require]

--- a/src/ansible_compat/config.py
+++ b/src/ansible_compat/config.py
@@ -6,12 +6,12 @@ import re
 import subprocess
 import sys
 from collections import UserDict
-from functools import lru_cache
 from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 from packaging.version import Version
 
 from ansible_compat.errors import InvalidPrerequisiteError, MissingAnsibleError
+from ansible_compat.ports import cache
 
 # mypy/pylint idiom for py36-py38 compatibility
 # https://github.com/python/typeshed/issues/3500#issuecomment-560958608
@@ -59,7 +59,7 @@ def parse_ansible_version(stdout: str) -> Version:
     raise InvalidPrerequisiteError("Unable to parse ansible cli version: %s" % stdout)
 
 
-@lru_cache()
+@cache
 def ansible_version(version: str = "") -> Version:
     """Return current Version object for Ansible.
 

--- a/src/ansible_compat/ports.py
+++ b/src/ansible_compat/ports.py
@@ -1,0 +1,18 @@
+"""Portability helpers."""
+import sys
+
+# Based on workarounds seen on https://github.com/python/mypy/issues/1362
+if sys.version_info >= (3, 8):
+    from functools import cached_property
+else:
+    from cached_property import cached_property
+
+if sys.version_info >= (3, 9):
+    from functools import cache
+else:
+    from functools import lru_cache
+
+    cache = lru_cache(maxsize=None)
+
+
+__all__ = ["cache", "cached_property"]


### PR DESCRIPTION
This should make it much easier for use to use the newer caching
functions in python across our projects.

Related: https://github.com/ansible-community/molecule/pull/3180