### PR TITLE
Add version_in_range method to Runtime

### DIFF
--- a/test/test_runtime.py
+++ b/test/test_runtime.py
@@ -5,7 +5,7 @@ import os
 import pathlib
 import subprocess
 from contextlib import contextmanager
-from typing import Any, Iterator, List, Type
+from typing import Any, Iterator, List, Type, Union
 
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
@@ -550,3 +550,21 @@ def test_runtime_env_ansible_library(monkeypatch: MonkeyPatch) -> None:
     runtime = Runtime()
     runtime.prepare_environment()
     assert path_name in runtime.config.default_module_path
+
+
+@pytest.mark.parametrize(
+    ("lower", "upper", "expected"),
+    (
+        ("1.0", "9999.0", True),
+        (None, "9999.0", True),
+        ("1.0", None, True),
+        ("9999.0", None, False),
+        (None, "1.0", False),
+    ),
+)
+def test_runtime_version_in_range(
+    lower: Union[str, None], upper: Union[str, None], expected: bool
+) -> None:
+    """Validate functioning of version_in_range."""
+    runtime = Runtime()
+    assert runtime.version_in_range(lower=lower, upper=upper) is expected

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ setenv =
   PIP_DISABLE_PIP_VERSION_CHECK = 1
   PIP_CONSTRAINT = {toxinidir}/constraints.txt
   PRE_COMMIT_COLOR = always
-  PYTEST_REQPASS = 62
+  PYTEST_REQPASS = 67
   FORCE_COLOR = 1
 allowlist_externals =
   sh


### PR DESCRIPTION
Adds a new API method that can easily be used to detect if ansible is within a specified range. That should cover the most common use case of Ansible version checking.

That was found as needed as we found a big number of places where we do the same checks and an extra benefit is that
the user will no longer have to import Version from packaging in order to make the version comparable.