### PR TITLE
Bump setuptools-scm version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     entry: >-
       sh -c 'git hash-object setup.py
       |
-      python -c raise\ SystemExit\(input\(\)\ !=\ \"f6d1010b609cbe816d3ef652eee452d09d52979f\"\)
+      python -c raise\ SystemExit\(input\(\)\ !=\ \"28da0d9dd407d1b3f931217f6f62ce34b98b74c6\"\)
       '
     pass_filenames: false
     language: system

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
-  "setuptools >= 42.0.0",  # required by pyproject+setuptools_scm integration
-  "setuptools_scm[toml] >= 3.5.0",  # required for "no-local-version" scheme
+  "setuptools >= 45.0.0",  # required by pyproject+setuptools_scm integration
+  "setuptools_scm >= 6.3.1",  # required for "no-local-version" scheme
   "setuptools_scm_git_archive >= 1.0",
   "wheel",
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,7 @@ zip_safe = False
 
 # These are required during `setup.py` run:
 setup_requires =
-  setuptools_scm>=1.15.0
+  setuptools_scm>=6.3.1
   setuptools_scm_git_archive>=1.0
 
 # These are required in actual runtime:

--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,5 @@ import setuptools
 # https://github.com/jazzband/pip-tools/issues/1278
 setuptools.setup(
     use_scm_version={"local_scheme": "no-local-version"},
-    setup_requires=["setuptools_scm[toml]>=3.5.0"],
+    setup_requires=["setuptools_scm>=6.3.1"],
 )


### PR DESCRIPTION
Also fixing bug uncovered by 6.3.0 related to us missing to mention toml extra in one place.

Related: https://github.com/psf/black/pull/2475#issuecomment-912730714