### PR TITLE
chore: update sphinx

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,7 +70,7 @@ htmlhelp_basename = 'ansible-compat'
 
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
-    'packaging': ('https://packaging.python.org/en/latest/', None),
+    'packaging': ('https://packaging.pypa.io/en/latest/', None),
 }
 
 

--- a/docs/requirements.in
+++ b/docs/requirements.in
@@ -1,4 +1,4 @@
 sphinx-autobuild>=0.7.1,<1.0
-sphinx>=4.0.0,<5.0
+sphinx>=4.2.0,<5.0
 sphinx_ansible_theme
 myst_parser

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -68,7 +68,7 @@ six==1.16.0
     # via livereload
 snowballstemmer==2.1.0
     # via sphinx
-sphinx==4.1.1
+sphinx==4.2.0
     # via
     #   -r docs/requirements.in
     #   myst-parser


### PR DESCRIPTION
- preparing for adding support for py3.10, as we will need sphinx 4.2.0 or newer.
- fix broken docs jobs due to incorrect URL

~Related: https://github.com/pypa/packaging.python.org/issues/995~
Related: https://github.com/ansible-community/devtools/issues/6