### PR TITLE
chore: fix pre-commit.ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,16 @@
 ---
+ci:
+  # format compatible with commitlint
+  autoupdate_commit_msg: "chore: pre-commit autoupdate"
+  autoupdate_schedule: monthly
+  autofix_commit_msg: |
+    chore: auto fixes from pre-commit.com hooks
+
+    for more information, see https://pre-commit.ci
+  skip:
+  # https://github.com/pre-commit-ci/issues/issues/55
+  - pip-compile
+  - pip-compile-docs
 repos:
 - repo: local
   hooks:

--- a/src/ansible_compat/ports.py
+++ b/src/ansible_compat/ports.py
@@ -8,7 +8,7 @@ else:
     from cached_property import cached_property
 
 if sys.version_info >= (3, 9):
-    from functools import cache
+    from functools import cache  # pylint: disable=no-name-in-module
 else:
     from functools import lru_cache
 


### PR DESCRIPTION
- Disable steps not compatible with pre-commit.ci when under it (our own GHA job still runs it)
- alters its update message and update schedule
 
This will ease reviews by auto-fixing simple linting errors.