### PR TITLE
Avoid tox usedevelop

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ requires =
   setuptools >= 41.4.0
   pip >= 19.3.0
 skip_missing_interpreters = True
+skipsdist = true
 
 [testenv]
 description =
@@ -20,14 +21,12 @@ description =
   ansible29: ansible 2.9
   ansible210: ansible-base 2.10
   ansible211: ansible-core 2.11
-extras =
-  retry
-  test
 deps =
   ansible29: ansible>=2.9,<2.10
   ansible210: ansible-base>=2.10,<2.11
   ansible211: ansible-core>=2.11,<2.12
   devel: ansible-core @ git+https://github.com/ansible/ansible.git  # GPLv3+
+  --editable .[retry,test]
 commands =
   ansible --version
   # We add coverage options but not making them mandatory as we do not want to force
@@ -57,9 +56,6 @@ setenv =
   FORCE_COLOR = 1
 allowlist_externals =
   sh
-# w/o usedevelop=true coverage capture fails with:
-# Coverage.py warning: No data was collected. (no-data-collected)
-usedevelop = true
 
 [testenv:lint]
 description = Run all linters
@@ -127,5 +123,5 @@ commands =
     docs/ "{toxworkdir}/html"
 deps =
   -r docs/requirements.txt
-usedevelop = true
+  --editable .
 passenv = *


### PR DESCRIPTION
Implements workaround for tox bug with usedevelop by relying on pip own
editable option.

Related: https://github.com/tox-dev/tox/issues/2197