### PR TITLE
Fix GHA release trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 name: release
 
 on:
-  create:
-    tags:
+  release:
+    types: [published]
 
 jobs:
   before-release:


### PR DESCRIPTION
Apparently create>tags event did not trigger the release workflow,
so we use the setup from molecule project, where it seems to be
working with release>published.
