### PR TITLE
Drop support for py36 and py37

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -99,8 +99,6 @@ jobs:
       matrix:
         python-version:
         # keep list sorted as it determines UI order too
-        - 3.6
-        - 3.7
         - 3.8
         - 3.9
         - "3.10"
@@ -112,12 +110,6 @@ jobs:
         # - windows-latest
         # - windows-2016
         include:
-        - tox_env: py36
-          os: ubuntu-20.04
-          python-version: 3.6
-        - tox_env: py37
-          os: ubuntu-20.04
-          python-version: 3.7
         - tox_env: py38
           os: ubuntu-20.04
           python-version: 3.8
@@ -130,9 +122,9 @@ jobs:
           os: ubuntu-20.04
           python-version: "3.10"
           devel: true
-        - tox_env: py36
+        - tox_env: py38
           os: macOS-latest
-          python-version: 3.6
+          python-version: 3.8
         - tox_env: py310
           os: macOS-latest
           python-version: "3.10"

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.6
+python_version = 3.8
 color_output = True
 error_summary = True
 disallow_untyped_calls = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,8 +30,6 @@ classifiers =
 
   Programming Language :: Python
   Programming Language :: Python :: 3
-  Programming Language :: Python :: 3.6
-  Programming Language :: Python :: 3.7
   Programming Language :: Python :: 3.8
   Programming Language :: Python :: 3.9
   Programming Language :: Python :: 3.10
@@ -50,7 +48,7 @@ keywords =
 
 [options]
 use_scm_version = True
-python_requires = >=3.6
+python_requires = >=3.8
 package_dir =
   = src
 packages = find:
@@ -58,7 +56,6 @@ zip_safe = False
 
 # These are required in actual runtime:
 install_requires =
-  cached_property ~= 1.5; python_version<="3.7"
   PyYAML
   subprocess-tee >= 0.3.5
 

--- a/src/ansible_compat/config.py
+++ b/src/ansible_compat/config.py
@@ -4,22 +4,13 @@ import copy
 import os
 import re
 import subprocess
-import sys
 from collections import UserDict
-from typing import TYPE_CHECKING, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Union
 
 from packaging.version import Version
 
 from ansible_compat.errors import InvalidPrerequisiteError, MissingAnsibleError
 from ansible_compat.ports import cache
-
-# mypy/pylint idiom for py36-py38 compatibility
-# https://github.com/python/typeshed/issues/3500#issuecomment-560958608
-if sys.version_info >= (3, 8):
-    from typing import Literal  # pylint: disable=no-name-in-module
-else:
-    from typing_extensions import Literal
-
 
 if TYPE_CHECKING:
     # https://github.com/PyCQA/pylint/issues/3285

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
   lint
   packaging
   docs
-  py{39,38,37,36}-{ansible29,ansible210,ansible211}
+  py{39,38}-{ansible29,ansible210,ansible211}
   py310-{ansible210,ansible211}
   py{310,39,38}-devel
 isolated_build = true


### PR DESCRIPTION
Related: https://github.com/ansible-community/molecule/pull/3436
Related: https://github.com/ansible-community/ansible-lint/pull/1850

Note: that there is one lint job failing that we resolve in follow-up because it requires upgrade of pip-tools, and we cannot do that before dropping support for old pythons.