### PR TITLE
Make cache_key portable

### DIFF
--- a/src/ansible_compat/prerun.py
+++ b/src/ansible_compat/prerun.py
@@ -5,8 +5,13 @@ import os
 
 def get_cache_dir(project_dir: str) -> str:
     """Compute cache directory to be used based on project path."""
+    # we only use the basename instead of the full path in order to ensure that
+    # we would use the same key regardless the location of the user home
+    # directory or where the project is clones (as long the project folder uses
+    # the same name).
+    basename = os.path.basename(project_dir).encode(encoding="utf-8")
     # 6 chars of entropy should be enough
-    cache_key = hashlib.sha256(os.path.abspath(project_dir).encode()).hexdigest()[:6]
+    cache_key = hashlib.sha256(basename).hexdigest()[:6]
     cache_dir = (
         os.getenv("XDG_CACHE_HOME", os.path.expanduser("~/.cache"))
         + "/ansible-compat/"


### PR DESCRIPTION
This will help getting the behavior more portable across different systems, as the cache key for specific project name should be the same, regardless location of user home directory or the source code location.

This is related to some challenges we observed with ansible-lint testing, where we want to make the output more predictable. Still, the same could affect other users.